### PR TITLE
add dependabot config for nuget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The goal of this PR is to add basic dependabot config for an automated way to keep Nuget packages up-to-date